### PR TITLE
Fix incorrect address computations (lvl. 11, 12 and 15) 

### DIFF
--- a/intro-to-arm/run
+++ b/intro-to-arm/run
@@ -1105,9 +1105,9 @@ class EmbryoARMFib(EmbryoARMBase):
         # movk is not needed, but for completeness
         self.harness = pwnlib.asm.asm(f"""
                             mov x3, #{hex(self.code_load_addr & 0xFFFF)}
-                            movk x3, #{hex((self.code_load_addr >> 16) & 0xFFFF0000)}, lsl 16
-                            movk x3, #{hex((self.code_load_addr >> 32) & 0xFFFF00000000)}, lsl 32
-                            movk x3, #{hex((self.code_load_addr >> 48) & 0xFFFF000000000000)}, lsl 48
+                            movk x3, #{hex((self.code_load_addr >> 16) & 0xFFFF)}, lsl 16
+                            movk x3, #{hex((self.code_load_addr >> 32) & 0xFFFF)}, lsl 32
+                            movk x3, #{hex((self.code_load_addr >> 48) & 0xFFFF)}, lsl 48
                             blr x3
                             """)
 

--- a/intro-to-arm/run
+++ b/intro-to-arm/run
@@ -628,7 +628,7 @@ class EmbryoARMMemoryAccessArray(EmbryoARMBase):
             "set x0 to the sum computed\n\n"
 
             "We will now set the following in preparation for your code:\n"
-            f"\t- [{hex(self.arr_addr)}:{hex(self.arr_addr + (self.arr_len * 4))}] = {{n qwords]}}\n"
+            f"\t- [{hex(self.arr_addr)}:{hex(self.arr_addr + (self.arr_len * 8))}] = {{n qwords]}}\n"
             f"\t- X0 = {hex(self.arr_addr)}\n"
             f"\t- X1 = {self.arr_len}\n"
         )
@@ -705,7 +705,7 @@ class EmbryoARMMemoryAccessArraySixInstr(EmbryoARMBase):
             "set x0 to the sum computed\n\n"
 
             "We will now set the following in preparation for your code:\n"
-            f"\t- [{hex(self.arr_addr)}:{hex(self.arr_addr + (self.arr_len * 4))}] = {{n qwords]}}\n"
+            f"\t- [{hex(self.arr_addr)}:{hex(self.arr_addr + (self.arr_len * 8))}] = {{n qwords]}}\n"
             f"\t- X0 = {hex(self.arr_addr)}\n"
             f"\t- X1 = {self.arr_len}\n"
         )


### PR DESCRIPTION
Fix incorrect address computation of array in levels EmbryoARMMemoryAccessArray (Level 11) and EmbryoARMMemoryAccessArraySixInstr (Level 12) 

The end address of the array storing numbers is incorrectly computed. Since the numbers stored in the array are qwords (8 bytes) and not dwords (4 bytes), the end address of the array should be computed by multiplying the number of array elements by 8 instead of 4.